### PR TITLE
Fix collision detection and resolution

### DIFF
--- a/MonoDreams.Examples/Message/CollisionMessage.cs
+++ b/MonoDreams.Examples/Message/CollisionMessage.cs
@@ -23,6 +23,7 @@ public readonly record struct CollisionMessage(
         int layer)
     {
         CollisionType collisionType = DetermineCollisionType(entity, target);
+        Console.WriteLine($"Collision detected: {entity} vs {target} at {contactPoint} (contact normal: {contactNormal}| time: {contactTime})");
         return new CollisionMessage(entity, target, contactPoint, contactNormal, contactTime, layer, collisionType);
     }
 

--- a/MonoDreams.Examples/Screens/LoadLevelExampleGameScreen.cs
+++ b/MonoDreams.Examples/Screens/LoadLevelExampleGameScreen.cs
@@ -105,8 +105,9 @@ public class LoadLevelExampleGameScreen : IGameScreen
             new LDtkEntityParserSystem(_world),
             new EntitySpawnSystem(_world, _content, _renderTargets));
         
-        // Systems that modify component state (can often be parallel)
-        var logicSystems = new ParallelSystem<GameState>(_parallelRunner,
+        // Collision pipeline must run sequentially (movement → velocity → detect → resolve → commit)
+        // Individual systems keep their internal _parallelRunner for entity-level parallelism
+        var logicSystems = new SequentialSystem<GameState>(
             new MovementSystem(_world, _parallelRunner),
             new OrbSystem(_world),
             new TransformVelocitySystem(_world, _parallelRunner),

--- a/MonoDreams.Examples/System/Collision/TransformCollisionResolutionSystem.cs
+++ b/MonoDreams.Examples/System/Collision/TransformCollisionResolutionSystem.cs
@@ -13,6 +13,7 @@ namespace MonoDreams.Examples.System.Collision;
 
 /// <summary>
 /// Collision resolution system that works with Transform component instead of Position.
+/// Uses float-precision CollisionRect to avoid integer truncation artifacts.
 /// </summary>
 public class TransformCollisionResolutionSystem<TCollisionMessage> : ISystem<GameState>
     where TCollisionMessage : ICollisionMessage
@@ -53,11 +54,11 @@ public class TransformCollisionResolutionSystem<TCollisionMessage> : ISystem<Gam
         var entity = collision.BaseEntity;
         ref var transform = ref entity.Get<Transform>();
         var collidable = entity.Get<BoxCollider>();
-        var dynamicRect = collidable.Bounds.AtPosition(transform.Position);
+        var dynamicRect = CollisionRect.FromBounds(collidable.Bounds, transform.Position);
 
         var collidingEntity = collision.CollidingEntity;
         var targetTransform = collidingEntity.Get<Transform>();
-        var targetRect = collidingEntity.Get<BoxCollider>().Bounds.AtPosition(targetTransform.Position);
+        var targetRect = CollisionRect.FromBounds(collidingEntity.Get<BoxCollider>().Bounds, targetTransform.Position);
 
         if (!TransformCollisionDetectionSystem<TCollisionMessage>.DynamicRectVsRect(dynamicRect, transform.Delta, targetRect,
                 out var contactPoint, out var contactNormal, out var contactTime)) return;

--- a/MonoDreams/Extensions/Monogame/CollisionRect.cs
+++ b/MonoDreams/Extensions/Monogame/CollisionRect.cs
@@ -1,0 +1,38 @@
+using Microsoft.Xna.Framework;
+
+namespace MonoDreams.Extensions.Monogame;
+
+/// <summary>
+/// Float-precision AABB for collision math. Eliminates integer truncation
+/// that occurs when using <see cref="Rectangle"/> with float entity positions.
+/// </summary>
+public readonly struct CollisionRect(Vector2 position, Vector2 size)
+{
+    public readonly Vector2 Position = position;
+    public readonly Vector2 Size = size;
+
+    public float Left => Position.X;
+    public float Top => Position.Y;
+    public float Right => Position.X + Size.X;
+    public float Bottom => Position.Y + Size.Y;
+    public float Width => Size.X;
+    public float Height => Size.Y;
+    public Vector2 Center => Position + Size / 2f;
+
+    public bool Intersects(CollisionRect other)
+    {
+        return Left < other.Right && Right > other.Left &&
+               Top < other.Bottom && Bottom > other.Top;
+    }
+
+    /// <summary>
+    /// Creates a CollisionRect from integer bounds offset by a float entity position,
+    /// preserving sub-pixel precision that <see cref="RectangleExtensions.AtPosition"/> loses.
+    /// </summary>
+    public static CollisionRect FromBounds(Rectangle bounds, Vector2 entityPosition)
+    {
+        return new CollisionRect(
+            bounds.Location.ToVector2() + entityPosition,
+            bounds.Size.ToVector2());
+    }
+}


### PR DESCRIPTION
## Summary
- **Float-precision collision rects**: Replace integer `Rectangle` with `CollisionRect` (float `Vector2` position/size) across both detection and resolution systems to eliminate truncation artifacts at sub-pixel positions.
- **Remove `contactTime < 0` filter**: This check was blocking wall-pinning collisions — entities resting on surfaces produce slightly negative `contactTime` values (e.g. `-0.01`) which the filter incorrectly rejected, causing entities to fall through floors/walls. The `contactNormal == Vector2.Zero` guard already handles ghost collisions and unresolvable diagonal hits.
- **Sequential collision pipeline**: Switch `logicSystems` from `ParallelSystem` to `SequentialSystem` to guarantee correct ordering (movement → velocity → detect → resolve → commit).
- **New `CollisionRect` struct**: Added `MonoDreams/Extensions/Monogame/CollisionRect.cs` with float-precision bounds, intersection tests, and factory method `FromBounds`.

## Test plan
- [x] Build passes: `dotnet build MonoDreams.Examples/MonoDreams.Examples.csproj`
- [x] Run game, load Level 2
- [x] Entity stops at walls in all 4 directions (floor, ceiling, left wall, right wall)
- [x] No ghost collision logs at `(0,0)` from overlapping static walls
- [x] No snapping/teleportation when sliding along walls

🤖 Generated with [Claude Code](https://claude.com/claude-code)