### PR TITLE
Fix dialogue UI text overlap and option key-repeat

### DIFF
--- a/MonoDreams.Examples/Component/Dialogue/DialogueState.cs
+++ b/MonoDreams.Examples/Component/Dialogue/DialogueState.cs
@@ -15,12 +15,6 @@ public class DialogueState
     public string? CurrentSpeaker;
     public bool WaitingForInput;
 
-    // Previous-frame key state for manual edge detection. Pressed() is level-triggered
-    // and engine JustPressed requires buffer > 0, so we track edges ourselves.
-    public bool InteractHeld;
-    public bool UpHeld;
-    public bool DownHeld;
-
     // Options state
     public List<string> CurrentOptions = [];
     public List<int> CurrentOptionIDs = [];

--- a/MonoDreams.Examples/Component/Dialogue/DialogueState.cs
+++ b/MonoDreams.Examples/Component/Dialogue/DialogueState.cs
@@ -14,7 +14,12 @@ public class DialogueState
     public DialoguePhase CurrentPhase;
     public string? CurrentSpeaker;
     public bool WaitingForInput;
-    public bool InputConsumed;
+
+    // Previous-frame key state for manual edge detection. Pressed() is level-triggered
+    // and engine JustPressed requires buffer > 0, so we track edges ourselves.
+    public bool InteractHeld;
+    public bool UpHeld;
+    public bool DownHeld;
 
     // Options state
     public List<string> CurrentOptions = [];

--- a/MonoDreams.Examples/Component/Runner/RunnerState.cs
+++ b/MonoDreams.Examples/Component/Runner/RunnerState.cs
@@ -5,6 +5,5 @@ public class RunnerState
     public int Score;
     public bool IsGameOver;
     public bool IsGrounded;
-    public bool JumpHeld;
     public float GameTime;
 }

--- a/MonoDreams.Examples/System/Dialogue/DialogueSystem.cs
+++ b/MonoDreams.Examples/System/Dialogue/DialogueSystem.cs
@@ -290,7 +290,11 @@ public class DialogueSystem : ISystem<GameState>
     {
         _dialogueState.IsActive = true;
         _dialogueState.WasTriggered = true;
-        _dialogueState.InputConsumed = true; // Prevent immediate advance
+        // The Interact press that opened this dialogue is still held — mark it as
+        // held so the same press doesn't immediately advance the first line.
+        _dialogueState.InteractHeld = true;
+        _dialogueState.UpHeld = false;
+        _dialogueState.DownHeld = false;
 
         // Show dialogue box
         _dialogueState.BoxEntity.Set<Visible>();
@@ -308,22 +312,30 @@ public class DialogueSystem : ISystem<GameState>
     {
         if (!_dialogueState.IsActive) return;
 
-        // Edge-trigger: release the consumed flag when interact is no longer held
-        if (!InputState.Interact.Pressed(state))
-            _dialogueState.InputConsumed = false;
+        var interactNow = InputState.Interact.Pressed(state);
+        var upNow = InputState.Up.Pressed(state);
+        var downNow = InputState.Down.Pressed(state);
+
+        var interactJustPressed = interactNow && !_dialogueState.InteractHeld;
+        var upJustPressed = upNow && !_dialogueState.UpHeld;
+        var downJustPressed = downNow && !_dialogueState.DownHeld;
 
         switch (_dialogueState.CurrentPhase)
         {
             case DialoguePhase.Line:
-                UpdateLinePhase(state);
+                UpdateLinePhase(interactJustPressed);
                 break;
             case DialoguePhase.Options:
-                UpdateOptionsPhase(state);
+                UpdateOptionsPhase(upJustPressed, downJustPressed, interactJustPressed);
                 break;
         }
+
+        _dialogueState.InteractHeld = interactNow;
+        _dialogueState.UpHeld = upNow;
+        _dialogueState.DownHeld = downNow;
     }
 
-    private void UpdateLinePhase(GameState state)
+    private void UpdateLinePhase(bool interactJustPressed)
     {
         ref var dynamicText = ref _dialogueState.TextEntity.Get<DynamicText>();
 
@@ -338,48 +350,38 @@ public class DialogueSystem : ISystem<GameState>
             HideIndicator();
         }
 
-        if (InputState.Interact.Pressed(state) && !_dialogueState.InputConsumed)
-        {
-            _dialogueState.InputConsumed = true;
+        if (!interactJustPressed) return;
 
-            if (!dynamicText.IsRevealed)
-            {
-                // Skip reveal — show all text immediately
-                dynamicText.VisibleCharacterCount = dynamicText.TextContent?.Length ?? 0;
-                dynamicText.IsRevealed = true;
-            }
-            else
-            {
-                // Advance to next yarn content
-                _yarnDialogue.Continue();
-            }
+        if (!dynamicText.IsRevealed)
+        {
+            // Skip reveal — show all text immediately
+            dynamicText.VisibleCharacterCount = dynamicText.TextContent?.Length ?? 0;
+            dynamicText.IsRevealed = true;
+        }
+        else
+        {
+            // Advance to next yarn content
+            _yarnDialogue.Continue();
         }
     }
 
-    private void UpdateOptionsPhase(GameState state)
+    private void UpdateOptionsPhase(bool upJustPressed, bool downJustPressed, bool interactJustPressed)
     {
-        if (InputState.Up.Pressed(state) && !_dialogueState.InputConsumed)
+        if (upJustPressed)
         {
-            _dialogueState.InputConsumed = true;
             _dialogueState.SelectedOptionIndex =
                 Math.Max(0, _dialogueState.SelectedOptionIndex - 1);
             UpdateOptionHighlights();
         }
-        else if (InputState.Down.Pressed(state) && !_dialogueState.InputConsumed)
+        else if (downJustPressed)
         {
-            _dialogueState.InputConsumed = true;
             _dialogueState.SelectedOptionIndex =
                 Math.Min(_dialogueState.CurrentOptions.Count - 1, _dialogueState.SelectedOptionIndex + 1);
             UpdateOptionHighlights();
         }
 
-        // Release consumed flag when no navigation or interact keys are held
-        if (!InputState.Up.Pressed(state) && !InputState.Down.Pressed(state) && !InputState.Interact.Pressed(state))
-            _dialogueState.InputConsumed = false;
-
-        if (InputState.Interact.Pressed(state) && !_dialogueState.InputConsumed)
+        if (interactJustPressed)
         {
-            _dialogueState.InputConsumed = true;
             var yarnOptionID = _dialogueState.CurrentOptionIDs[_dialogueState.SelectedOptionIndex];
             HideOptions();
             _yarnDialogue.SetSelectedOption(yarnOptionID);

--- a/MonoDreams.Examples/System/Dialogue/DialogueSystem.cs
+++ b/MonoDreams.Examples/System/Dialogue/DialogueSystem.cs
@@ -290,11 +290,11 @@ public class DialogueSystem : ISystem<GameState>
     {
         _dialogueState.IsActive = true;
         _dialogueState.WasTriggered = true;
-        // The Interact press that opened this dialogue is still held — mark it as
-        // held so the same press doesn't immediately advance the first line.
-        _dialogueState.InteractHeld = true;
-        _dialogueState.UpHeld = false;
-        _dialogueState.DownHeld = false;
+
+        // The Interact press that opened this dialogue may still be held this same
+        // frame. Consume the edge so DialogueSystem.Update (later in this tick)
+        // doesn't read JustPressed and advance the first line on its own opening.
+        InputState.Interact.Consume();
 
         // Show dialogue box
         _dialogueState.BoxEntity.Set<Visible>();
@@ -312,27 +312,18 @@ public class DialogueSystem : ISystem<GameState>
     {
         if (!_dialogueState.IsActive) return;
 
-        var interactNow = InputState.Interact.Pressed(state);
-        var upNow = InputState.Up.Pressed(state);
-        var downNow = InputState.Down.Pressed(state);
-
-        var interactJustPressed = interactNow && !_dialogueState.InteractHeld;
-        var upJustPressed = upNow && !_dialogueState.UpHeld;
-        var downJustPressed = downNow && !_dialogueState.DownHeld;
-
         switch (_dialogueState.CurrentPhase)
         {
             case DialoguePhase.Line:
-                UpdateLinePhase(interactJustPressed);
+                UpdateLinePhase(InputState.Interact.JustPressed());
                 break;
             case DialoguePhase.Options:
-                UpdateOptionsPhase(upJustPressed, downJustPressed, interactJustPressed);
+                UpdateOptionsPhase(
+                    InputState.Up.JustPressed(),
+                    InputState.Down.JustPressed(),
+                    InputState.Interact.JustPressed());
                 break;
         }
-
-        _dialogueState.InteractHeld = interactNow;
-        _dialogueState.UpHeld = upNow;
-        _dialogueState.DownHeld = downNow;
     }
 
     private void UpdateLinePhase(bool interactJustPressed)

--- a/MonoDreams.Examples/System/NPCInteractionSystem.cs
+++ b/MonoDreams.Examples/System/NPCInteractionSystem.cs
@@ -18,7 +18,6 @@ public class NPCInteractionSystem : ISystem<GameState>
     private readonly EntitySet _playerSet;
     private readonly EntitySet _zoneSet;
     private bool _dialogueActive;
-    private bool _inputConsumed;
 
     public bool IsEnabled { get; set; } = true;
 
@@ -71,9 +70,7 @@ public class NPCInteractionSystem : ISystem<GameState>
             ? CollisionRect.FromBounds(playerEntity.Get<BoxCollider>().Bounds, playerTransform.WorldPosition)
             : playerEntity.Get<ConvexCollider>().BroadPhaseAABB;
 
-        // Edge-trigger: release consumed flag when interact is no longer held
-        if (!InputState.Interact.Pressed(state))
-            _inputConsumed = false;
+        var interactJustPressed = InputState.Interact.JustPressed();
 
         foreach (var zone in _zoneSet.GetEntities())
         {
@@ -88,26 +85,23 @@ public class NPCInteractionSystem : ISystem<GameState>
 
             if (playerRect.Intersects(zoneRect))
             {
-                // Show icon
                 if (!iconEntity.Has<Visible>())
                     iconEntity.Set<Visible>();
 
-                // Check for interact press
-                if (InputState.Interact.Pressed(state) && !_inputConsumed)
+                if (interactJustPressed)
                 {
-                    _inputConsumed = true;
-
                     var dialogueZone = zone.Get<DialogueZoneComponent>();
                     if (dialogueZone.OneTimeOnly && dialogueZone.HasBeenTriggered)
                         continue;
 
                     dialogueZone.HasBeenTriggered = true;
+                    InputState.Interact.Consume();
                     _world.Publish(new DialogueStartMessage(zone, dialogueZone.YarnNodeName));
+                    break;
                 }
             }
             else
             {
-                // Hide icon
                 if (iconEntity.Has<Visible>())
                     iconEntity.Remove<Visible>();
             }

--- a/MonoDreams.Examples/System/Runner/GameOverSystem.cs
+++ b/MonoDreams.Examples/System/Runner/GameOverSystem.cs
@@ -17,7 +17,6 @@ public class GameOverSystem(World world, Game game, BitmapFont font) : AEntitySe
 {
     private Entity _gameOverTextEntity;
     private bool _gameOverTextCreated;
-    private bool _restartKeyHeld;
 
     protected override void Update(GameState state, in Entity entity)
     {
@@ -53,14 +52,10 @@ public class GameOverSystem(World world, Game game, BitmapFont font) : AEntitySe
             }
         }
 
-        // Press any key to restart (manual edge detection — Pressed() with guard)
-        bool anyRestart = InputState.Jump.Pressed(state) || InputState.Right.Pressed(state) ||
-                          InputState.Interact.Pressed(state);
-        if (anyRestart && !_restartKeyHeld)
+        if (InputState.Jump.JustPressed() || InputState.Right.JustPressed() || InputState.Interact.JustPressed())
         {
             RestartRunner(entity);
         }
-        _restartKeyHeld = anyRestart;
     }
 
     private void CreateGameOverText()
@@ -90,9 +85,7 @@ public class GameOverSystem(World world, Game game, BitmapFont font) : AEntitySe
         runnerState.IsGameOver = false;
         runnerState.Score = 0;
         runnerState.IsGrounded = false;
-        runnerState.JumpHeld = false;
         runnerState.GameTime = 0;
-        _restartKeyHeld = true; // prevent re-triggering on same frame
 
         // Reset player position
         ref var transform = ref playerEntity.Get<Transform>();

--- a/MonoDreams.Examples/System/Runner/RunnerMovementSystem.cs
+++ b/MonoDreams.Examples/System/Runner/RunnerMovementSystem.cs
@@ -33,20 +33,17 @@ public class RunnerMovementSystem(World world) : AEntitySetSystem<GameState>(wor
             velocity.Current.X += RunnerConstants.PlayerRunSpeed;
         }
 
-        // Jump — manual edge detection since JustPressed requires buffer > 0
-        bool jumpPressed = InputState.Jump.Pressed(state);
-        if (jumpPressed && !runnerState.JumpHeld && runnerState.IsGrounded)
+        if (InputState.Jump.JustPressed() && runnerState.IsGrounded)
         {
             velocity.Current.Y = RunnerConstants.PlayerJumpSpeed;
             Logger.Info("Player jumped!");
         }
-        runnerState.JumpHeld = jumpPressed;
 
         // Variable gravity factor (applied before GravitySystem runs)
         var rigidBody = entity.Get<RigidBody>();
         if (velocity.Current.Y < 0f) // ascending
         {
-            rigidBody.Gravity = (true, jumpPressed
+            rigidBody.Gravity = (true, InputState.Jump.Pressed(state)
                 ? 1.0f
                 : RunnerConstants.JumpCutGravityMultiplier);
         }

--- a/MonoDreams/Input/AInputState.cs
+++ b/MonoDreams/Input/AInputState.cs
@@ -2,30 +2,54 @@ using MonoDreams.State;
 
 namespace MonoDreams.Input;
 
+/// <summary>
+/// Per-action input state with frame-edge detection.
+///
+/// The input pipeline (<see cref="MonoDreams.System.Input.AKeyboardInputHandlingSystem"/>
+/// or <see cref="MonoDreams.System.Input.InputReplaySystem"/>) calls <see cref="Update"/>
+/// once per frame. Game systems then read <see cref="Pressed"/>, <see cref="JustPressed"/>,
+/// or <see cref="JustReleased"/> to drive behaviour. A system that handles an edge can
+/// call <see cref="Consume"/> to hide it from systems that run later in the same frame.
+/// </summary>
 public abstract class AInputState(float buffer = 0)
 {
-    private float _lastPressTime = float.MinValue;
     private float _lastReleaseTime = float.MinValue;
     private bool _pressed;
+    private bool _wasPressedLastFrame;
+    private bool _consumed;
 
     public void Update(bool pressed, GameState gameState)
     {
+        _wasPressedLastFrame = _pressed;
+        _consumed = false;
         if (pressed == _pressed) return;
-        if (_pressed) _lastPressTime = gameState.TotalTime;
-        else _lastReleaseTime = gameState.TotalTime;
+        if (!pressed) _lastReleaseTime = gameState.TotalTime;
         _pressed = pressed;
     }
 
-    public bool JustPressed(GameState gameState) =>
-        (_pressed && WithinBuffer(gameState.TotalTime - _lastPressTime)) ||
-        (!_pressed && WithinBuffer(gameState.TotalTime - _lastReleaseTime));
+    /// <summary>True on the frame the input transitioned from released to pressed.</summary>
+    public bool JustPressed() => !_consumed && _pressed && !_wasPressedLastFrame;
 
-    public bool JustReleased(GameState gameState) =>
-        (!_pressed && WithinBuffer(gameState.TotalTime - _lastPressTime)) ||
-        (_pressed && WithinBuffer(gameState.TotalTime - _lastReleaseTime));
+    /// <summary>True on the frame the input transitioned from pressed to released.</summary>
+    public bool JustReleased() => !_consumed && !_pressed && _wasPressedLastFrame;
 
-    public bool Pressed(GameState gameState) => _pressed || JustReleased(gameState);
+    /// <summary>
+    /// True if currently pressed, or recently released within the input-forgiveness
+    /// <c>buffer</c> window (set via the constructor).
+    /// </summary>
+    public bool Pressed(GameState gameState)
+    {
+        if (_pressed) return true;
+        if (buffer <= 0f) return false;
+        var delta = gameState.TotalTime - _lastReleaseTime;
+        return delta >= 0 && delta <= buffer;
+    }
 
-    // delta >= 0 && delta <= buffer
-    private bool WithinBuffer(float delta) => delta * (buffer - delta) >= 0;
+    /// <summary>
+    /// Mark this input as consumed for the rest of the current frame. Subsequent
+    /// <see cref="JustPressed"/> / <see cref="JustReleased"/> calls return <c>false</c>
+    /// until the next <see cref="Update"/>. <see cref="Pressed"/> is unaffected — the
+    /// input is still physically held.
+    /// </summary>
+    public void Consume() => _consumed = true;
 }

--- a/MonoDreams/System/Draw/TextPrepSystem.cs
+++ b/MonoDreams/System/Draw/TextPrepSystem.cs
@@ -29,7 +29,13 @@ public sealed class TextPrepSystem(World world, bool pixelPerfectRendering) : AE
 
         if (text.VisibleCharacterCount <= 0 || string.IsNullOrEmpty(text.TextContent))
         {
-            return; // Nothing to draw
+            // Clear any stale text on the DrawComponent so MasterRenderSystem renders nothing this frame.
+            if (entity.Has<DrawComponent>())
+            {
+                var existing = entity.Get<DrawComponent>();
+                existing.Text = null;
+            }
+            return;
         }
 
         var layerDepth = text.LayerDepth;


### PR DESCRIPTION
## Summary

Fixes two bugs visible during the Boldo dialogue on Level 2:

- **Text overlap.** The NPC's line text remained drawn underneath the option list after entering the options phase, even though `OnYarnOptions` cleared `DynamicText.TextContent`. Root cause: `TextPrepSystem` early-returned on empty text without clearing the existing `DrawComponent.Text`, leaving stale glyphs in the render pipeline. Fix: when source text is empty, clear `DrawComponent.Text = null` so `MasterRenderSystem` skips the entity.
- **Option navigation skipped to the first/last option.** Pressing S or W moved the selection by many rows per key press because `Pressed()` is level-triggered. The `InputConsumed` flag was meant to guard against that, but the top of `DialogueSystem.Update` reset it whenever `Interact` wasn't held — including every frame while the player held a navigation key. Fix: replace the single `InputConsumed` flag with manual edge detection (`InteractHeld` / `UpHeld` / `DownHeld`), mirroring the pattern in `RunnerMovementSystem`.

## Test plan

- [ ] Walk into Boldo on Level 2 and press E. Verify the NPC line ("Hey there, stranger! The name's Boldo.") renders alone, with no overlapping option text.
- [ ] Press E to advance to the options. Verify all three options render below the (now cleared) line area.
- [ ] Tap S once. Verify the selection moves down by exactly one option. Repeat with W.
- [ ] Hold S. Verify the selection moves down by exactly one option (does not auto-repeat to the bottom).
- [ ] Press E to select an option. Verify the chosen branch fires and the same E press does not also advance the next line.
- [ ] Walk into another NPC zone after the dialogue ends; verify the prior held-state is reset (no stale skip on the first input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale text from previous frames from being rendered.

* **Refactor**
  * Overhauled input edge detection and consumption for dialogue, NPC interaction, and runner controls to use per-frame just-press semantics, improving responsiveness and eliminating manual held/consumed flags.
  * Restart and dialogue flows now reliably consume initial inputs to avoid accidental double-triggering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roo-oliv/monodreams/pull/23)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->