### PR TITLE
Fix dialogue indicator persisting between lines, bump its size

### DIFF
--- a/MonoDreams.Examples/System/Dialogue/DialogueSystem.cs
+++ b/MonoDreams.Examples/System/Dialogue/DialogueSystem.cs
@@ -58,7 +58,8 @@ public class DialogueSystem : ISystem<GameState>
         var boxHeight = 120;
         var rootPosition = new Vector2(20, virtualHeight - boxHeight - 20);
         var textOffset = new Vector2(16, 16);
-        var indicatorOffset = new Vector2(boxWidth - 28, boxHeight - 24);
+        const int indicatorSize = 32;
+        var indicatorOffset = new Vector2(boxWidth - indicatorSize - 12, boxHeight - indicatorSize - 8);
 
         // Create root entity
         _rootTransform = new Transform(rootPosition);
@@ -132,7 +133,7 @@ public class DialogueSystem : ISystem<GameState>
         {
             SpriteSheet = indicatorTexture,
             Source = new Rectangle(0, 0, indicatorTexture.Width, indicatorTexture.Height),
-            Size = new Vector2(16, 16),
+            Size = new Vector2(indicatorSize, indicatorSize),
             Color = Color.White,
             Target = RenderTargetID.UI,
             LayerDepth = _layers.GetDepth(GameDrawLayer.DialogueUI, +0.01f)
@@ -450,6 +451,11 @@ public class DialogueSystem : ISystem<GameState>
     {
         if (_dialogueState.IndicatorEntity.Has<Visible>())
             _dialogueState.IndicatorEntity.Remove<Visible>();
+
+        // UI render target always renders regardless of Visible — clear the texture
+        // so MasterRenderSystem skips drawing the stale DrawComponent.
+        ref var indicatorDraw = ref _dialogueState.IndicatorEntity.Get<DrawComponent>();
+        indicatorDraw.Texture = null;
     }
 
     // --- Deactivation ---


### PR DESCRIPTION
## Summary
- Clear `DrawComponent.Texture` in `HideIndicator()` so the "press E to continue" indicator actually disappears while the next line is revealing — the UI render target ignores `Visible` by design (per `docs/rendering/premises.md` "Three render targets, two behaviors"), so removing the tag alone wasn't enough.
- Bump the indicator from 16×16 to 32×32 (offset recomputed to keep the same right/bottom margin against the 1880×120 dialogue box) so it reads as a clear prompt at the 1920×1080 virtual resolution.

## Why the first line was fine but later lines weren't
`DrawComponent.Texture` is `null` on a fresh entity. `SpritePrepSystem` only writes to it when `Visible` is present. Until the first line fully revealed, the indicator had never been `Visible`, so its Texture stayed `null` and `MasterRenderSystem` skipped it. Once it became Visible (then later un-Visible at the next `Continue()`), its Texture was populated and stuck — the UI render path doesn't gate on `Visible`, so it kept drawing. `HideIndicator` now nulls Texture to match the same hide-pattern `DeactivateDialogue` already uses for `BoxEntity`.

## Test plan
- [ ] Launch `MonoDreams.Examples`, select Level 2.
- [ ] Walk into the dialogue NPC and advance past the first line: indicator should hide during reveal of line 2+ and reappear once the line is fully revealed.
- [ ] Confirm the indicator is visibly larger than before (32×32 vs 16×16).
- [ ] Other UI sprites (dialogue box, options) render unaffected; dialogue end leaves no ghost indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)